### PR TITLE
[codex] feature Pocket No on docs home

### DIFF
--- a/content/docs/projects/(mobile-app)/pocket-no.mdx
+++ b/content/docs/projects/(mobile-app)/pocket-no.mdx
@@ -38,6 +38,10 @@ Pocket No is a single-purpose mobile app that helps you say "no" with style. Tap
 - expo-quick-actions & @bacons/apple-targets (iOS native surfaces)
 - expo-haptics & expo-clipboard
 
+### Links
+
+[Landing Page](https://pocket-no.ctey.dev/)
+
 <GithubInfo
     owner="Chinteyley"
     repo="Pocket-No"

--- a/src/components/bento/ProjectsCard.tsx
+++ b/src/components/bento/ProjectsCard.tsx
@@ -26,10 +26,10 @@ const featuredProjects = [
     href: "/docs/projects/jomnouy",
   },
   {
-    title: "SnapPosts",
-    description: "AI-powered social media poster creator",
+    title: "Pocket No",
+    description: "Witty ways to say no with one tap",
     category: "mobile" as const,
-    href: "/docs/projects/snapposts",
+    href: "/docs/projects/pocket-no",
   },
   {
     title: "Neko",


### PR DESCRIPTION
This updates the `ctey-docs` portfolio site so Pocket No is surfaced as a featured project instead of only existing in the project index.

Before this change, the Pocket No docs page existed but did not link to its live landing page, and the homepage featured projects card still highlighted SnapPosts as the mobile project. That meant the newest Pocket No landing page was harder to discover from the main portfolio surface.

The fix does two things. First, it adds a dedicated landing-page link to the Pocket No project documentation page using the same content pattern already used by other project pages. Second, it replaces the homepage featured mobile project card so Pocket No is now promoted directly from the home bento grid.

This is a content and routing-surface update only. No public APIs or data contracts changed.

Validation used:
- `bun install`
- `bun run build`
