### PR TITLE
[codex] redesign landing page with Nothing-style bento

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -45,6 +45,17 @@
 
 :root {
   --radius: 0.625rem;
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+  --nothing-red: #ff2b2b;
+  --nothing-panel-bg: rgb(255 255 255 / 82%);
+  --nothing-panel-border: rgb(0 0 0 / 12%);
+  --nothing-panel-shine: rgb(255 255 255 / 80%);
+  --nothing-panel-shadow: rgb(0 0 0 / 10%);
+  --nothing-tile-bg: rgb(0 0 0 / 4%);
+  --nothing-tile-border: rgb(0 0 0 / 10%);
+  --nothing-dot: rgb(0 0 0 / 14%);
+  --nothing-hover-red: rgb(255 43 43 / 8%);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -79,6 +90,14 @@
 }
 
 .dark {
+  --nothing-panel-bg: rgb(18 18 18 / 92%);
+  --nothing-panel-border: rgb(255 255 255 / 14%);
+  --nothing-panel-shine: rgb(255 255 255 / 8%);
+  --nothing-panel-shadow: rgb(0 0 0 / 40%);
+  --nothing-tile-bg: rgb(255 255 255 / 5.5%);
+  --nothing-tile-border: rgb(255 255 255 / 10%);
+  --nothing-dot: rgb(255 255 255 / 15%);
+  --nothing-hover-red: rgb(255 43 43 / 10%);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -118,5 +137,165 @@
   }
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: geometricPrecision;
+  }
+}
+
+@layer components {
+  .nothing-panel {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1rem;
+    border: 1px solid var(--nothing-panel-border);
+    background: var(--nothing-panel-bg);
+    box-shadow:
+      0 1px 0 var(--nothing-panel-shine) inset,
+      0 20px 60px var(--nothing-panel-shadow);
+    transition-property: border-color, box-shadow, transform;
+    transition-duration: 220ms;
+    transition-timing-function: var(--ease-out);
+  }
+
+  .nothing-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: radial-gradient(var(--nothing-dot) 1px, transparent 1px);
+    background-size: 16px 16px;
+    mask-image: linear-gradient(135deg, black, transparent 58%);
+    opacity: 0.28;
+  }
+
+  .nothing-panel::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--nothing-panel-shine),
+      transparent
+    );
+    opacity: 0;
+    transform: translate3d(-100%, 0, 0);
+    transition-property: opacity, transform;
+    transition-duration: 240ms;
+    transition-timing-function: var(--ease-out);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .nothing-panel:hover {
+      border-color: rgb(255 43 43 / 34%);
+      box-shadow:
+        0 1px 0 var(--nothing-panel-shine) inset,
+        0 24px 70px var(--nothing-panel-shadow);
+    }
+
+    .nothing-panel:hover::after {
+      opacity: 0.6;
+      transform: translate3d(100%, 0, 0);
+    }
+  }
+
+  .nothing-dot-field {
+    position: absolute;
+    inset: -24px -24px auto auto;
+    width: 190px;
+    height: 190px;
+    background-image: radial-gradient(currentColor 1.5px, transparent 1.5px);
+    background-size: 13px 13px;
+    color: var(--nothing-dot);
+    mask-image: radial-gradient(circle, black, transparent 68%);
+    opacity: 0.5;
+  }
+
+  .nothing-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    color: var(--foreground);
+  }
+
+  .nothing-red-light {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: var(--nothing-red);
+    box-shadow: 0 0 22px color-mix(in srgb, var(--nothing-red) 60%, transparent);
+  }
+
+  .nothing-chip {
+    display: inline-flex;
+    min-height: 2rem;
+    align-items: center;
+    border-radius: 999px;
+    border: 1px solid var(--nothing-tile-border);
+    padding: 0 0.75rem;
+    background: var(--nothing-tile-bg);
+  }
+
+  .nothing-tile,
+  .nothing-command,
+  .nothing-project {
+    position: relative;
+    display: flex;
+    min-height: 2.5rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--nothing-tile-border);
+    background: var(--nothing-tile-bg);
+    transition-property: background-color, border-color, color, transform;
+    transition-duration: 180ms;
+    transition-timing-function: var(--ease-out);
+  }
+
+  .nothing-tile {
+    align-items: center;
+    padding: 0.75rem;
+  }
+
+  .nothing-command {
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0 1rem;
+  }
+
+  .nothing-project {
+    height: 100%;
+    flex-direction: column;
+    padding: 1rem;
+  }
+
+  .nothing-tile:active,
+  .nothing-command:active,
+  .nothing-project:active {
+    transform: scale(0.96);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .nothing-tile:hover,
+    .nothing-command:hover,
+    .nothing-project:hover {
+      border-color: color-mix(in srgb, var(--nothing-red) 65%, transparent);
+      background-color: var(--nothing-hover-red);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nothing-panel,
+    .nothing-panel::after,
+    .nothing-tile,
+    .nothing-command,
+    .nothing-project {
+      transition-duration: 0ms;
+    }
   }
 }

--- a/src/components/bento/AboutCard.tsx
+++ b/src/components/bento/AboutCard.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "motion/react";
 import { Sparkles, GitBranch } from "lucide-react";
 
 const interests = [
@@ -10,20 +7,17 @@ const interests = [
 
 export function AboutCard() {
   return (
-    <div className="h-full flex flex-col">
-      <h2 className="text-lg font-semibold mb-4">Passions</h2>
-      <div className="flex flex-col gap-3 flex-1">
-        {interests.map((interest, i) => (
-          <motion.div
+    <div className="flex h-full flex-col">
+      <h2 className="mb-5 text-lg font-semibold">Passions</h2>
+      <div className="flex flex-1 flex-col gap-3">
+        {interests.map((interest) => (
+          <div
             key={interest.label}
-            initial={{ opacity: 0, x: -10 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.7 + i * 0.1, duration: 0.3 }}
-            className="flex items-center gap-3 p-3 rounded-xl bg-muted/50"
+            className="nothing-tile min-h-14 justify-start gap-3 px-4"
           >
-            <interest.icon className="w-5 h-5 text-primary" />
-            <span className="text-sm font-medium">{interest.label}</span>
-          </motion.div>
+            <interest.icon className="h-4 w-4 text-foreground" />
+            <span className="text-sm font-semibold">{interest.label}</span>
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/bento/BentoGrid.tsx
+++ b/src/components/bento/BentoGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { motion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import { ReactNode } from "react";
 
 interface BentoCellProps {
@@ -11,20 +11,25 @@ interface BentoCellProps {
 }
 
 export function BentoCell({ children, index, className }: BentoCellProps) {
+  const reduceMotion = useReducedMotion();
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20, scale: 0.95 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
+      initial={
+        reduceMotion
+          ? { opacity: 1 }
+          : {
+              opacity: 0,
+              transform: "translate3d(0, 18px, 0) scale(0.97)",
+            }
+      }
+      animate={{ opacity: 1, transform: "translate3d(0, 0, 0) scale(1)" }}
       transition={{
-        duration: 0.5,
-        delay: index * 0.1,
-        ease: [0.25, 0.46, 0.45, 0.94],
+        duration: reduceMotion ? 0 : 0.42,
+        delay: reduceMotion ? 0 : index * 0.07,
+        ease: [0.23, 1, 0.32, 1],
       }}
-      className={cn(
-        "rounded-2xl border border-border bg-card/80 backdrop-blur-md p-6",
-        "hover:border-primary/30 transition-colors duration-300",
-        className
-      )}
+      className={cn("nothing-panel group/bento p-6", className)}
     >
       {children}
     </motion.div>
@@ -40,7 +45,7 @@ export function BentoGrid({ children, className }: BentoGridProps) {
   return (
     <div
       className={cn(
-        "grid grid-cols-1 md:grid-cols-6 lg:grid-cols-12 gap-4 w-full max-w-6xl mx-auto",
+        "grid w-full max-w-6xl grid-cols-1 gap-4 md:grid-cols-6 lg:grid-cols-12",
         className
       )}
     >

--- a/src/components/bento/ContactCard.tsx
+++ b/src/components/bento/ContactCard.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "motion/react";
 import { Mail, Github, Twitter } from "lucide-react";
 import Link from "next/link";
 
@@ -26,23 +23,21 @@ const contacts = [
 
 export function ContactCard() {
   return (
-    <div className="h-full flex flex-col">
-      <h2 className="text-lg font-semibold mb-4">Get in Touch</h2>
+    <div className="flex h-full flex-col">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold">Get in Touch</h2>
+        <span className="font-mono text-[0.65rem] uppercase text-muted-foreground/70">
+          Open channel
+        </span>
+      </div>
+
       <div className="flex flex-wrap gap-3">
-        {contacts.map((contact, i) => {
+        {contacts.map((contact) => {
           const content = (
-            <motion.div
-              key={contact.label}
-              initial={{ opacity: 0, x: -10 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.9 + i * 0.1, duration: 0.3 }}
-              className={`flex items-center gap-3 px-4 py-3 rounded-xl bg-muted/50 ${
-                contact.href ? "hover:bg-muted transition-colors cursor-pointer" : ""
-              }`}
-            >
-              <contact.icon className="w-4 h-4 text-primary" />
+            <span className="nothing-command">
+              <contact.icon className="h-4 w-4 text-foreground" />
               <span className="text-sm font-medium">{contact.label}</span>
-            </motion.div>
+            </span>
           );
 
           if (contact.href) {

--- a/src/components/bento/HeroSection.tsx
+++ b/src/components/bento/HeroSection.tsx
@@ -1,46 +1,39 @@
-"use client";
-
-import { motion } from "motion/react";
-
 export function HeroSection() {
   return (
-    <div className="flex flex-col justify-center h-full min-h-[280px]">
-      <motion.p
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.2, duration: 0.4 }}
-        className="text-sm font-medium text-primary mb-2"
-      >
-        Hello, I&apos;m
-      </motion.p>
+    <div className="relative flex h-full min-h-[300px] flex-col justify-between overflow-hidden">
+      <div className="nothing-dot-field" aria-hidden="true" />
 
-      <motion.h1
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.4 }}
-        className="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-4"
-      >
-        Chintey Ley
-      </motion.h1>
+      <div className="relative flex items-center justify-between gap-4">
+        <p className="nothing-kicker">
+          <span className="nothing-red-light" aria-hidden="true" />
+          CTEY / 001
+        </p>
+        <p className="font-mono text-[0.65rem] uppercase text-muted-foreground/70">
+          TypeScript + Native UI
+        </p>
+      </div>
 
-      <motion.p
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.4, duration: 0.4 }}
-        className="text-xl md:text-2xl text-muted-foreground font-medium mb-4"
-      >
-        Software Developer
-      </motion.p>
+      <div className="relative space-y-5">
+        <div>
+          <p className="mb-2 font-mono text-xs uppercase text-muted-foreground">
+            Software Developer
+          </p>
+          <h1 className="max-w-[9ch] text-balance text-5xl font-black leading-[0.9] tracking-normal md:text-6xl lg:text-7xl">
+            Chintey Ley
+          </h1>
+        </div>
 
-      <motion.p
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.5, duration: 0.4 }}
-        className="text-base text-muted-foreground max-w-md"
-      >
-        Building digital experiences with TypeScript, React & React Native.
-        Let&apos;s create something amazing together.
-      </motion.p>
+        <p className="max-w-md text-pretty text-base leading-7 text-muted-foreground md:text-lg">
+          Building sharp web and mobile products with TypeScript, React,
+          Next.js, and Expo.
+        </p>
+      </div>
+
+      <div className="relative flex flex-wrap gap-2 pt-8 font-mono text-[0.68rem] uppercase text-muted-foreground">
+        <span className="nothing-chip">React Native</span>
+        <span className="nothing-chip">Next.js</span>
+        <span className="nothing-chip">Open Source</span>
+      </div>
     </div>
   );
 }

--- a/src/components/bento/ProjectsCard.tsx
+++ b/src/components/bento/ProjectsCard.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "motion/react";
 import { ArrowRight, Laptop, Smartphone, Brain, Monitor } from "lucide-react";
 import Link from "next/link";
 
@@ -9,13 +6,6 @@ const categoryIcons = {
   mobile: Smartphone,
   ml: Brain,
   mac: Monitor,
-};
-
-const categoryColors = {
-  web: "bg-blue-500/10 text-blue-500",
-  mobile: "bg-green-500/10 text-green-500",
-  ml: "bg-purple-500/10 text-purple-500",
-  mac: "bg-orange-500/10 text-orange-500",
 };
 
 const featuredProjects = [
@@ -41,47 +31,41 @@ const featuredProjects = [
 
 export function ProjectsCard() {
   return (
-    <div className="h-full flex flex-col">
-      <div className="flex items-center justify-between mb-4">
+    <div className="flex h-full flex-col">
+      <div className="mb-5 flex items-center justify-between gap-4">
         <h2 className="text-lg font-semibold">Featured Projects</h2>
         <Link
           href="/docs/projects"
-          className="text-sm text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
+          className="inline-flex min-h-10 items-center gap-1 rounded-full px-3 font-mono text-xs uppercase text-muted-foreground transition-[color,background-color,transform] duration-200 ease-[var(--ease-out)] hover:bg-foreground/5 hover:text-foreground active:scale-[0.96]"
         >
-          View all <ArrowRight className="w-3 h-3" />
+          View all <ArrowRight className="h-3 w-3" />
         </Link>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 flex-1">
-        {featuredProjects.map((project, i) => {
+      <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-3">
+        {featuredProjects.map((project) => {
           const CategoryIcon = categoryIcons[project.category];
           return (
-            <motion.div
+            <Link
               key={project.title}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.8 + i * 0.1, duration: 0.3 }}
+              href={project.href}
+              className="nothing-project group/project"
             >
-              <Link
-                href={project.href}
-                className="flex flex-col h-full p-4 rounded-xl bg-muted/50 hover:bg-muted transition-colors group"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <span className={`p-1.5 rounded-lg ${categoryColors[project.category]}`}>
-                    <CategoryIcon className="w-3.5 h-3.5" />
-                  </span>
-                  <span className="text-xs font-medium text-muted-foreground capitalize">
-                    {project.category}
-                  </span>
-                </div>
-                <h3 className="font-semibold mb-1 group-hover:text-primary transition-colors">
-                  {project.title}
-                </h3>
-                <p className="text-xs text-muted-foreground line-clamp-2">
-                  {project.description}
-                </p>
-              </Link>
-            </motion.div>
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-foreground text-background">
+                  <CategoryIcon className="h-4 w-4" />
+                </span>
+                <span className="font-mono text-[0.65rem] uppercase text-muted-foreground">
+                  {project.category}
+                </span>
+              </div>
+              <h3 className="mb-2 font-semibold transition-colors duration-200 ease-[var(--ease-out)] group-hover/project:text-[var(--nothing-red)]">
+                {project.title}
+              </h3>
+              <p className="line-clamp-3 text-pretty text-xs leading-5 text-muted-foreground">
+                {project.description}
+              </p>
+            </Link>
           );
         })}
       </div>

--- a/src/components/bento/SkillsCard.tsx
+++ b/src/components/bento/SkillsCard.tsx
@@ -1,13 +1,10 @@
-"use client";
-
-import { motion } from "motion/react";
 import {
   FileCode2,
   Atom,
   Rocket,
   Globe,
   Palette,
-  Rabbit
+  Package
 } from "lucide-react";
 
 const skills = [
@@ -16,27 +13,30 @@ const skills = [
   { name: "Expo", icon: Rocket },
   { name: "Next.js", icon: Globe },
   { name: "Tailwind", icon: Palette },
-  { name: "Bun", icon: Rabbit },
+  { name: "Bun", icon: Package },
 ];
 
 export function SkillsCard() {
   return (
-    <div className="h-full flex flex-col">
-      <h2 className="text-lg font-semibold mb-4">Tech Stack</h2>
-      <div className="grid grid-cols-3 gap-3 flex-1">
-        {skills.map((skill, i) => (
-          <motion.div
+    <div className="flex h-full flex-col">
+      <div className="mb-5 flex items-center justify-between gap-4">
+        <h2 className="text-lg font-semibold">Tech Stack</h2>
+        <span className="font-mono text-[0.65rem] uppercase text-muted-foreground/70">
+          06 modules
+        </span>
+      </div>
+
+      <div className="grid flex-1 grid-cols-3 gap-3">
+        {skills.map((skill) => (
+          <div
             key={skill.name}
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ delay: 0.6 + i * 0.05, duration: 0.3 }}
-            className="flex flex-col items-center justify-center gap-2 p-3 rounded-xl bg-muted/50 hover:bg-muted transition-colors"
+            className="nothing-tile min-h-[78px] flex-col justify-center gap-2 text-center"
           >
-            <skill.icon className="w-6 h-6 text-primary" />
-            <span className="text-xs font-medium text-muted-foreground">
+            <skill.icon className="h-5 w-5 text-foreground" />
+            <span className="text-xs font-semibold text-muted-foreground">
               {skill.name}
             </span>
-          </motion.div>
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- redesigned the root landing bento grid with Nothing-inspired panels, dot-matrix texture, monochrome tiles, and a red accent
- preserved the existing Hero, Tech Stack, Passions, Featured Projects, and Contact sections
- tightened motion, hover, active, and reduced-motion behavior with exact transition properties

## Validation
- pnpm exec tsc --noEmit
- browser checked http://localhost:3000/ at desktop 1440x1000, mobile 390x844, and light theme

## Notes
- pnpm build compiles and passes TypeScript, then fails during prerender of /docs/projects/neko because the existing GitHub repository fetch returns 401 Bad credentials