### PR TITLE
Add animated logo mark

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -232,6 +232,46 @@
     box-shadow: 0 0 22px color-mix(in srgb, var(--nothing-red) 60%, transparent);
   }
 
+  .ctey-logo-motion {
+    overflow: visible;
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: ctey-logo-settle 900ms var(--ease-out) both;
+    transition:
+      filter 180ms var(--ease-out),
+      transform 180ms var(--ease-out);
+  }
+
+  .ctey-logo-line {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+    animation: ctey-logo-draw-in 860ms var(--ease-out) both;
+  }
+
+  .ctey-logo-line-left {
+    animation-delay: 0ms;
+  }
+
+  .ctey-logo-line-center {
+    stroke: var(--nothing-red);
+    animation-delay: 180ms;
+  }
+
+  .ctey-logo-soft .ctey-logo-line-center {
+    stroke: color-mix(in srgb, currentColor 48%, var(--nothing-red) 52%);
+  }
+
+  .ctey-logo-line-right {
+    animation-delay: 360ms;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    a:hover .ctey-logo-motion {
+      filter: drop-shadow(0 0 10px color-mix(in srgb, var(--nothing-red) 38%, transparent));
+      transform: translate3d(0, -1px, 0) scale(1.04);
+    }
+  }
+
   .nothing-chip {
     display: inline-flex;
     min-height: 2rem;
@@ -294,8 +334,42 @@
     .nothing-panel::after,
     .nothing-tile,
     .nothing-command,
-    .nothing-project {
+    .nothing-project,
+    .ctey-logo-motion,
+    .ctey-logo-line {
+      animation: none;
       transition-duration: 0ms;
     }
+
+    .ctey-logo-line {
+      stroke-dashoffset: 0;
+    }
+  }
+}
+
+@keyframes ctey-logo-draw-in {
+  0%,
+  10% {
+    stroke-dashoffset: 1;
+    opacity: 0.38;
+  }
+
+  100% {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}
+
+@keyframes ctey-logo-settle {
+  0% {
+    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--nothing-red) 35%, transparent));
+    opacity: 0.72;
+    transform: translate3d(0, 1px, 0) scale(0.96);
+  }
+
+  100% {
+    filter: drop-shadow(0 0 0 color-mix(in srgb, var(--nothing-red) 0%, transparent));
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
   }
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -253,12 +253,12 @@
   }
 
   .ctey-logo-line-center {
-    stroke: var(--nothing-red);
+    stroke: currentColor;
     animation-delay: 180ms;
   }
 
   .ctey-logo-soft .ctey-logo-line-center {
-    stroke: color-mix(in srgb, currentColor 48%, var(--nothing-red) 52%);
+    stroke: currentColor;
   }
 
   .ctey-logo-line-right {
@@ -267,7 +267,7 @@
 
   @media (hover: hover) and (pointer: fine) {
     a:hover .ctey-logo-motion {
-      filter: drop-shadow(0 0 10px color-mix(in srgb, var(--nothing-red) 38%, transparent));
+      filter: drop-shadow(0 0 10px color-mix(in srgb, currentColor 28%, transparent));
       transform: translate3d(0, -1px, 0) scale(1.04);
     }
   }
@@ -362,13 +362,13 @@
 
 @keyframes ctey-logo-settle {
   0% {
-    filter: drop-shadow(0 0 14px color-mix(in srgb, var(--nothing-red) 35%, transparent));
+    filter: drop-shadow(0 0 14px color-mix(in srgb, currentColor 24%, transparent));
     opacity: 0.72;
     transform: translate3d(0, 1px, 0) scale(0.96);
   }
 
   100% {
-    filter: drop-shadow(0 0 0 color-mix(in srgb, var(--nothing-red) 0%, transparent));
+    filter: drop-shadow(0 0 0 color-mix(in srgb, currentColor 0%, transparent));
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(1);
   }

--- a/src/app/layout.config.tsx
+++ b/src/app/layout.config.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { AnimatedLogo } from '@/components/AnimatedLogo';
 /**
  * Shared layout configurations
  *
@@ -10,13 +11,7 @@ export const baseOptions: BaseLayoutProps = {
   nav: {
     title: (
         <>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-                 stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-                 className="">
-                <path d="M10 16h4"></path>
-                <path d="m2 16 4-4-4-4"></path>
-                <path d="m18 16 4-4-4-4"></path>
-            </svg>
+            <AnimatedLogo />
             CTEY
         </>
     ),

--- a/src/components/AnimatedLogo.tsx
+++ b/src/components/AnimatedLogo.tsx
@@ -1,0 +1,44 @@
+import type { SVGProps } from 'react';
+import { clsx } from 'clsx';
+
+type AnimatedLogoProps = SVGProps<SVGSVGElement> & {
+  size?: number;
+};
+
+export function AnimatedLogo({
+  size = 24,
+  className,
+  ...props
+}: AnimatedLogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={clsx('ctey-logo-motion', className)}
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        className="ctey-logo-line ctey-logo-line-left"
+        pathLength="1"
+        d="m2 16 4-4-4-4"
+      />
+      <path
+        className="ctey-logo-line ctey-logo-line-center"
+        pathLength="1"
+        d="M10 16h4"
+      />
+      <path
+        className="ctey-logo-line ctey-logo-line-right"
+        pathLength="1"
+        d="m18 16 4-4-4-4"
+      />
+    </svg>
+  );
+}

--- a/src/components/bento/HeroSection.tsx
+++ b/src/components/bento/HeroSection.tsx
@@ -1,7 +1,13 @@
+import { AnimatedLogo } from '@/components/AnimatedLogo';
+
 export function HeroSection() {
   return (
     <div className="relative flex h-full min-h-[300px] flex-col justify-between overflow-hidden">
       <div className="nothing-dot-field" aria-hidden="true" />
+      <AnimatedLogo
+        size={84}
+        className="ctey-logo-soft pointer-events-none absolute right-8 top-14 hidden size-24 text-foreground/10 md:block"
+      />
 
       <div className="relative flex items-center justify-between gap-4">
         <p className="nothing-kicker">

--- a/src/components/docs/FluxDocsLayout.tsx
+++ b/src/components/docs/FluxDocsLayout.tsx
@@ -15,12 +15,12 @@ import { buttonVariants } from 'fumadocs-ui/components/ui/button';
 import { useSearchContext } from 'fumadocs-ui/contexts/search';
 import Link from 'fumadocs-core/link';
 import { usePathname } from 'fumadocs-core/framework';
-import Image from 'next/image';
 import type { Root as PageTreeRoot } from 'fumadocs-core/page-tree';
 import { Languages } from 'lucide-react';
 import { clsx } from 'clsx';
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
+import { AnimatedLogo } from '@/components/AnimatedLogo';
 
 type FluxDocsLayoutProps = {
   tree: PageTreeRoot;
@@ -121,13 +121,7 @@ export function FluxDocsLayout({ tree }: FluxDocsLayoutProps) {
                   href={props.nav?.url ?? '/'}
                   className="inline-flex items-center gap-2.5 rounded-md transition-opacity hover:opacity-85"
                 >
-                  <Image
-                    src="/ctey.png"
-                    alt="CTEY logo"
-                    width={28}
-                    height={28}
-                    className="size-7 rounded-sm object-contain dark:invert dark:brightness-0"
-                  />
+                  <AnimatedLogo size={28} className="size-7 shrink-0" />
                   {slots.navTitle ? (
                     <slots.navTitle className="inline-flex items-center gap-2.5 text-sm font-semibold" />
                   ) : null}


### PR DESCRIPTION
## Summary
- add a reusable animated CTEY SVG logo mark
- replace static nav/logo usage with the animated mark
- add a softened decorative hero variant and hide it on mobile to avoid title overlap

## Validation
- pnpm exec tsc --noEmit
- checked localhost:3000 rendered HTML for the responsive hero logo class

## Note
- pnpm build was attempted earlier and still fails during prerender because GitHub returns 401 Bad credentials for /docs/projects/password-game; this appears unrelated to the logo changes.