### PR TITLE
remove animated logo mark from hero section

### DIFF
--- a/src/components/bento/HeroSection.tsx
+++ b/src/components/bento/HeroSection.tsx
@@ -1,13 +1,7 @@
-import { AnimatedLogo } from '@/components/AnimatedLogo';
-
 export function HeroSection() {
   return (
     <div className="relative flex h-full min-h-[300px] flex-col justify-between overflow-hidden">
       <div className="nothing-dot-field" aria-hidden="true" />
-      <AnimatedLogo
-        size={84}
-        className="ctey-logo-soft pointer-events-none absolute right-8 top-14 hidden size-24 text-foreground/10 md:block"
-      />
 
       <div className="relative flex items-center justify-between gap-4">
         <p className="nothing-kicker">


### PR DESCRIPTION
## Summary
- Drop the `AnimatedLogo` (the `>_>` mark) that overlapped the hero on `md+` screens

## Test plan
- [x] `bun dev` and confirm the hero card no longer shows the corner logo