### PR TITLE
Fix double-bounce landing page entry on Firefox and Safari

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -152,7 +152,7 @@
     box-shadow:
       0 1px 0 var(--nothing-panel-shine) inset,
       0 20px 60px var(--nothing-panel-shadow);
-    transition-property: border-color, box-shadow, transform;
+    transition-property: border-color, box-shadow;
     transition-duration: 220ms;
     transition-timing-function: var(--ease-out);
   }
@@ -364,12 +364,10 @@
   0% {
     filter: drop-shadow(0 0 14px color-mix(in srgb, currentColor 24%, transparent));
     opacity: 0.72;
-    transform: translate3d(0, 1px, 0) scale(0.96);
   }
 
   100% {
     filter: drop-shadow(0 0 0 color-mix(in srgb, currentColor 0%, transparent));
     opacity: 1;
-    transform: translate3d(0, 0, 0) scale(1);
   }
 }

--- a/src/components/bento/BentoGrid.tsx
+++ b/src/components/bento/BentoGrid.tsx
@@ -18,12 +18,9 @@ export function BentoCell({ children, index, className }: BentoCellProps) {
       initial={
         reduceMotion
           ? { opacity: 1 }
-          : {
-              opacity: 0,
-              transform: "translate3d(0, 18px, 0) scale(0.97)",
-            }
+          : { opacity: 0, y: 18, scale: 0.97 }
       }
-      animate={{ opacity: 1, transform: "translate3d(0, 0, 0) scale(1)" }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={{
         duration: reduceMotion ? 0 : 0.42,
         delay: reduceMotion ? 0 : index * 0.07,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The landing page bento grid entry animation appeared to "bounce twice" in Firefox and Safari, while Chrome looked smooth.

## Root cause

Two animation systems were fighting over `transform` on the same elements:

1. **Bento panels** — Motion animates `transform` over 420ms on `.nothing-panel`, but that class also had a 220ms CSS `transition` on `transform`. Firefox and Safari apply the CSS transition on top of each Motion frame update, producing a second easing pass at the end.

2. **Nav logo** — `ctey-logo-settle` keyframes animated `transform` while `.ctey-logo-motion` also had a CSS `transition` on `transform`, causing the same conflict during page load.

Chrome's compositor often masks this overlap; Firefox and Safari do not.

## Fix

- Remove `transform` from `.nothing-panel` transition (hover only changes border/shadow anyway)
- Use Motion's separate `y` and `scale` props instead of a compound `transform` string for more reliable cross-browser interpolation
- Animate only `opacity` and `filter` in the logo settle keyframes so hover `transform` transitions remain intact

## Testing

- `pnpm run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed3a6-4a49-7271-be03-268bf7a09c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed3a6-4a49-7271-be03-268bf7a09c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

