### PR TITLE
canonical the bacii countdown docs page to the live app

### DIFF
--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -47,20 +47,28 @@ export async function generateMetadata({
   const page = source.getPage(slug);
   if (!page) notFound();
   const image = ['/og/docs', ...slug, 'image.png'].join('/');
+
+  // The Bac II countdown has a dedicated live app. Point search authority to it
+  // so the app — not this docs page — ranks for "bacii countdown".
+  const canonical =
+    slug.join('/') === 'projects/bacii-countdown'
+      ? 'https://bacii.ctey.dev'
+      : `https://ctey.dev/docs/${slug.join('/')}`;
+
   return {
     title: page.data.title,
     description: page.data.description,
     openGraph: {
       images: image,
       siteName: page.data.title,
-      url: `https://ctey.dev/docs/${slug.join('/')}`,
+      url: canonical,
     },
     twitter: {
       card: 'summary_large_image',
       images: image,
     },
     alternates: {
-      canonical: `https://ctey.dev/docs/${slug.join('/')}`,
+      canonical,
     },
   };
 }


### PR DESCRIPTION
## Why
`ctey.dev/docs/projects/bacii-countdown` was outranking the live app at `bacii.ctey.dev` for the query **"bacii countdown"**. We want the app to own that query.

## Change
- **`src/app/docs/[[...slug]]/page.tsx`** — special-case the `projects/bacii-countdown` slug so its `canonical` (and OG `url`) point to `https://bacii.ctey.dev`. Every other docs page is unaffected.

This tells Google to consolidate ranking signals for this content into the app. Paired with the app-side PR (richer title/h1/description), the cross-domain canonical has equivalent content to attach to.

## Tradeoff
The docs page will likely drop out of search results for "bacii countdown" — intended.

## Verification
⚠️ `next build`/`next lint` not run (no `node_modules` in the working checkout). Single-conditional metadata change.